### PR TITLE
Minor fixes for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ OS_TYPE = POSIX
 # The 'OS' environment variable is 'Windows_NT' on Windows systems.
 ifeq ($(OS),Windows_NT)
 	OS_TYPE = WINDOWS
+else
+	UNAME_S := $(shell uname -s)
 endif
 
 # --- Windows Build ---
@@ -40,7 +42,11 @@ else
 	# On POSIX, we link against the installed readline library
 	LIBS = -lcurl -lz -lreadline
 	RM = rm -f
-	STRIP = strip -s
+	ifeq ($(UNAME_S),Darwin)
+		STRIP = strip
+	else
+		STRIP = strip -s
+	endif
 endif
 
 OBJ = $(SRC:.c=.o)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TARGET_NAME = gemini-cli
 SRC_COMMON = gemini-cli.c cJSON.c
 OBJ_COMMON = $(SRC_COMMON:.c=.o)
 # Common compiler and linker flags
-CFLAGS = -Wall -Wextra -g -O2 -I.
+CFLAGS += -std=c99 -Wall -Wextra -g -O2 -I.
 #LDFLAGS =
 
 # --- Platform-Specific Configuration ---


### PR DESCRIPTION
1. Fix strip.
2. Use `-std=c99` as the minimum required standard.

Addresses these errors:
```
/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_sysutils_gemini-cli/gemini-cli/work/compwrap/cc/usr/bin/gcc-4.2 -Os -arch ppc -Wall -Wextra -g -O2 -I. -c gemini-cli.c -o gemini-cli.o
/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_sysutils_gemini-cli/gemini-cli/work/compwrap/cc/usr/bin/gcc-4.2 -Os -arch ppc -Wall -Wextra -g -O2 -I. -c cJSON.c -o cJSON.o
gemini-cli.c: In function ‘generate_session’:
gemini-cli.c:294: warning: missing braces around initializer
gemini-cli.c:294: warning: (near initialization for ‘state.api_key’)
gemini-cli.c:294: warning: missing initializer
gemini-cli.c:294: warning: (near initialization for ‘state.origin’)
gemini-cli.c:303: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:328: error: redefinition of ‘i’
gemini-cli.c:303: error: previous definition of ‘i’ was here
gemini-cli.c:328: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:427: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:431: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:481: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:656: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:713: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1005: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1052: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1054: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1131: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1144: error: redefinition of ‘i’
gemini-cli.c:1131: error: previous definition of ‘i’ was here
gemini-cli.c:1144: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1165: error: redefinition of ‘i’
gemini-cli.c:1144: error: previous definition of ‘i’ was here
gemini-cli.c:1165: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1200: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1247: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1253: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c: In function ‘build_free_request_payload’:
gemini-cli.c:1617: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1629: error: redefinition of ‘i’
gemini-cli.c:1617: error: previous definition of ‘i’ was here
gemini-cli.c:1629: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1647: error: redefinition of ‘i’
gemini-cli.c:1629: error: previous definition of ‘i’ was here
gemini-cli.c:1647: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1657: error: redefinition of ‘i’
gemini-cli.c:1647: error: previous definition of ‘i’ was here
gemini-cli.c:1657: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1658: error: redefinition of ‘i’
gemini-cli.c:1657: error: previous definition of ‘i’ was here
gemini-cli.c:1658: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1668: error: redefinition of ‘i’
gemini-cli.c:1658: error: previous definition of ‘i’ was here
gemini-cli.c:1668: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1671: error: redefinition of ‘i’
gemini-cli.c:1668: error: previous definition of ‘i’ was here
gemini-cli.c:1671: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1678: error: redefinition of ‘i’
gemini-cli.c:1671: error: previous definition of ‘i’ was here
gemini-cli.c:1678: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1680: error: redefinition of ‘i’
gemini-cli.c:1678: error: previous definition of ‘i’ was here
gemini-cli.c:1680: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1683: error: redefinition of ‘i’
gemini-cli.c:1680: error: previous definition of ‘i’ was here
gemini-cli.c:1683: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:1685: error: redefinition of ‘i’
gemini-cli.c:1683: error: previous definition of ‘i’ was here
gemini-cli.c:1685: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c: In function ‘send_free_api_request’:
gemini-cli.c:1730: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c: In function ‘list_available_models’:
gemini-cli.c:2009: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c: In function ‘export_history_to_markdown’:
gemini-cli.c:2124: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:2132: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c: In function ‘send_api_request’:
gemini-cli.c:2301: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c: In function ‘parse_common_options’:
gemini-cli.c:2506: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:2626: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:2687: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c: In function ‘build_request_json’:
gemini-cli.c:3366: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:3373: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c: In function ‘load_history_from_file’:
gemini-cli.c:3699: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c: In function ‘add_content_to_history’:
gemini-cli.c:3763: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c: In function ‘free_content’:
gemini-cli.c:3795: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c: In function ‘free_pending_attachments’:
gemini-cli.c:3814: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c: In function ‘free_history’:
gemini-cli.c:3836: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c: In function ‘gzip_compress’:
gemini-cli.c:3864: warning: missing initializer
gemini-cli.c:3864: warning: (near initialization for ‘strm.avail_in’)
gemini-cli.c: In function ‘base64_encode’:
gemini-cli.c:4177: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c:4192: error: conflicting types for ‘i’
gemini-cli.c:4177: error: previous definition of ‘i’ was here
gemini-cli.c:4192: error: ‘for’ loop initial declaration used outside C99 mode
gemini-cli.c: In function ‘main’:
gemini-cli.c:4295: error: ‘for’ loop initial declaration used outside C99 mode
make: *** [gemini-cli.o] Error 1
```
```
/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_sysutils_gemini-cli/gemini-cli/work/compwrap/cc/usr/bin/gcc-4.2 -Os -std=c99 -arch ppc -Wall -Wextra -g -O2 -I. -c gemini-cli.c -o gemini-cli.o
/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_sysutils_gemini-cli/gemini-cli/work/compwrap/cc/usr/bin/gcc-4.2 -Os -std=c99 -arch ppc -Wall -Wextra -g -O2 -I. -c cJSON.c -o cJSON.o
gemini-cli.c: In function ‘generate_session’:
gemini-cli.c:294: warning: missing braces around initializer
gemini-cli.c:294: warning: (near initialization for ‘state.api_key’)
gemini-cli.c:294: warning: missing initializer
gemini-cli.c:294: warning: (near initialization for ‘state.origin’)
gemini-cli.c: In function ‘gzip_compress’:
gemini-cli.c:3864: warning: missing initializer
gemini-cli.c:3864: warning: (near initialization for ‘strm.avail_in’)
/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_sysutils_gemini-cli/gemini-cli/work/compwrap/cc/usr/bin/gcc-4.2 -L/opt/local/lib -Wl,-headerpad_max_install_names -arch ppc -o gemini-cli gemini-cli.o cJSON.o -lcurl -lz -lreadline
strip -s gemini-cli
fatal error: strip: no files specified
make: *** [gemini-cli] Error 1
```

3. Also do not override CFLAGS set in environment; they are needed, for example, for FAT builds or Rosetta.